### PR TITLE
Catch EOFError when loading incompletely-written Optimize .npy results

### DIFF
--- a/merlin/analysis/optimize.py
+++ b/merlin/analysis/optimize.py
@@ -234,9 +234,10 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
         try:
             return self.dataSet.load_pickle_analysis_result(
                 'chromatic_corrections', self.analysisName)
-        # OSError and ValueError are raised if the previous file is not
-        # completely written
-        except (FileNotFoundError, OSError, ValueError):
+        # OSError, ValueError and EOFError are raised if the previous file is
+        # not completely written (EOFError e.g. from np.load reading a
+        # momentarily empty .npy during an NFS write / attribute-cache race)
+        except (FileNotFoundError, OSError, ValueError, EOFError):
             # TODO - this is messy. It can be broken into smaller subunits and
             # most parts could be included in a chromatic aberration class
             previousTransformations = \
@@ -332,9 +333,10 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
         try:
             return self.dataSet.load_numpy_analysis_result(
                 'scale_factors', self.analysisName)
-        # OSError and ValueError are raised if the previous file is not
-        # completely written
-        except (FileNotFoundError, OSError, ValueError):
+        # OSError, ValueError and EOFError are raised if the previous file is
+        # not completely written (EOFError e.g. from np.load reading a
+        # momentarily empty .npy during an NFS write / attribute-cache race)
+        except (FileNotFoundError, OSError, ValueError, EOFError):
             refactors = np.array([self.dataSet.load_numpy_analysis_result(
                     'scale_refactors', self.analysisName, resultIndex=i)
                 for i in range(self.parameters['fov_per_iteration'])])
@@ -362,9 +364,10 @@ class OptimizeIteration(decode.BarcodeSavingParallelAnalysisTask):
         try:
             return self.dataSet.load_numpy_analysis_result(
                 'backgrounds', self.analysisName)
-        # OSError and ValueError are raised if the previous file is not
-        # completely written
-        except (FileNotFoundError, OSError, ValueError):
+        # OSError, ValueError and EOFError are raised if the previous file is
+        # not completely written (EOFError e.g. from np.load reading a
+        # momentarily empty .npy during an NFS write / attribute-cache race)
+        except (FileNotFoundError, OSError, ValueError, EOFError):
             refactors = np.array([self.dataSet.load_numpy_analysis_result(
                     'background_refactors', self.analysisName, resultIndex=i)
                 for i in range(self.parameters['fov_per_iteration'])])


### PR DESCRIPTION
## Problem

`OptimizeIteration`'s three result loaders (`chromatic_corrections`, `scale_factors`, `backgrounds`) wrap `load_numpy_analysis_result` in a `try/except` whose comment states it exists to fall back to reconstruction when *"the previous file is not completely written"*:

```python
except (FileNotFoundError, OSError, ValueError):
```

However, `np.load` on a **momentarily-empty** `.npy` raises `EOFError`, which is **not** in that tuple. On a shared filesystem this crashes the Optimize task instead of recovering.

### How it triggers

Running on a Slurm/NFS cluster, an `Optimize` iteration failed with:

```
File "merlin/analysis/optimize.py", line 333, in get_scale_factors
    return self.dataSet.load_numpy_analysis_result('scale_factors', self.analysisName)
File "merlin/core/dataset.py", line 525, in load_numpy_analysis_result
    return np.load(savePath)
EOFError: No data left in file
```

The previous iteration's `scale_factors.npy` was valid on disk (correct size, shape `(20,)`). The read simply hit it during the write window: the dependency's `.done` marker became visible on the consumer node **before** the aggregated `scale_factors.npy` write had propagated (NFS flush / attribute-cache lag), so `np.load` read zero bytes → `EOFError`. Because `EOFError` isn't caught, the intended fallback (rebuild from the per-fragment `*_refactors_*.npy` files) never runs and the whole pipeline halts.

## Fix

Add `EOFError` to all three `except` tuples so the existing fallback triggers as designed, and update the comments to note it.

```python
except (FileNotFoundError, OSError, ValueError, EOFError):
```

No behavior change on the happy path; this only affects the recovery branch that was already meant to handle incompletely-written files.